### PR TITLE
Fix MKS Robin E3 BLTOUCH and Fan PWM timer conflicts

### DIFF
--- a/Marlin/src/HAL/STM32F1/timers.h
+++ b/Marlin/src/HAL/STM32F1/timers.h
@@ -80,7 +80,7 @@ typedef uint16_t hal_timer_t;
   //#define TEMP_TIMER_NUM      4  // 2->4, Timer 2 for Stepper Current PWM
 #endif
 
-#if MB(BTT_SKR_MINI_E3_V1_0, BTT_SKR_E3_DIP, BTT_SKR_MINI_E3_V1_2, MKS_ROBIN_LITE)
+#if MB(BTT_SKR_MINI_E3_V1_0, BTT_SKR_E3_DIP, BTT_SKR_MINI_E3_V1_2, MKS_ROBIN_LITE, MKS_ROBIN_E3D, MKS_ROBIN_E3)
   // SKR Mini E3 boards use PA8 as FAN_PIN, so TIMER 1 is used for Fan PWM.
   #ifdef STM32_HIGH_DENSITY
     #define SERVO0_TIMER_NUM 8  // tone.cpp uses Timer 4


### PR DESCRIPTION


### Description

As with SKR E3 cards, the Fan PWM is connected to pin number PA8 in MKS Robin E3 cards. For this reason, there is a timer conflict between servo0 and Fan PWM.


### Requirements

MKS Robin E3
MKS Robin E3D


### Benefits

The problems that occur when using BLTOUCH on these cards are eliminated.


### Related Issues

Strange operation of BL Touch sensor on MKS Robin E3 and E3D motherboards, fan working when BL Touch sensor is working.
